### PR TITLE
split build and deploy flows

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -59,140 +59,28 @@ env:
 
 jobs:
   Build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    # outputs:
-    #   appenv: ${{ steps.setappenv.outputs.env }}
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-
-      - name: Setup buildx
-        uses: docker/setup-buildx-action@v1
-        id: buildx
-        with:
-          install: true
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}-v2
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.sha }}-v2
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,format=long
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          file: ${{ env.DOCKERFILE }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      # This only works for pub repos
-      # - id: setappenv
-      #   run: |
-      #     if [[ "$GITHUB_REF_NAME" == *"develop"* ]]; then
-      #       echo "::set-output name=DEPLOY_ENV::development"
-      #     elif [[ "$GITHUB_REF_NAME" == *"master"* ]]; then
-      #       echo "::set-output name=DEPLOY_ENV::production"
-      #     fi
+    uses: ./build_branch.yaml
+    with:
+      dockerfile: ${{ inputs.dockerfile }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   Deploy:
+    uses: ./deploy_branch.yaml
     needs: [Build]
-    runs-on: ubuntu-latest
-    # environment: ${{needs.Build.outputs.appenv}}
-    steps:
-      - uses: actions/checkout@v2
+    with:
+      appname: ${{ inputs.appname }}
+      helm_name: ${{ inputs.helm_name }}
+      helm_timeout: ${{ inputs.helm_timeout }}
+      dev_ns: ${{ inputs.dev_ns }}
+      stg_ns: ${{ inputs.stg_ns }}
+      prod_ns: ${{ inputs.prod_ns }}
+      use_ssm: ${{ inputs.use_ssm }}
+      simple_deploy: ${{ inputs.simple_deploy }}
+      release: ${{ inputs.release }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Prepare deployment
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-        run: |
-          if [[ "$SHOULD_RELEASE" == true ]] || [[ "$GITHUB_REF_NAME"  == *"master"* ]] || [[ "$GITHUB_REF_NAME" == *"main"* ]] || [[ "$GITHUB_REF_NAME" == *"nextprod"* ]]; then
-            echo "VALUES=_k/${APP_NAME}/values-prod.yaml" >> $GITHUB_ENV
-            echo "CONF_ENV=prod" >> $GITHUB_ENV
-            echo "NAMESPACE=${PROD_NS}" >> $GITHUB_ENV
-            exit 0
-          fi
-
-          if [[ "$GITHUB_REF_NAME" == *"develop"* ]]; then
-            echo "VALUES=_k/${APP_NAME}/values-dev.yaml" >> $GITHUB_ENV
-            echo "CONF_ENV=dev" >> $GITHUB_ENV
-            echo "NAMESPACE=${DEV_NS}" >> $GITHUB_ENV
-          elif [[ "$GITHUB_REF_NAME"  == *"staging"* ]] || [[ "$GITHUB_REF_NAME"  == *"nextstaging"* ]]; then
-            echo "VALUES=_k/${APP_NAME}/values-stage.yaml" >> $GITHUB_ENV
-            echo "CONF_ENV=stage" >> $GITHUB_ENV
-            echo "NAMESPACE=${STG_NS}" >> $GITHUB_ENV
-          elif [[ "$GITHUB_REF_NAME"  == *"next"* ]]; then
-            echo "VALUES=_k/${APP_NAME}/values-next.yaml" >> $GITHUB_ENV
-            echo "CONF_ENV=next" >> $GITHUB_ENV
-            echo "NAMESPACE=${PROD_NS}" >> $GITHUB_ENV
-          fi
-
-      - uses: azure/setup-kubectl@v1
-        with:
-          version: "v1.22.4"
-
-      - uses: actions/setup-node@v2
-      - uses: azure/setup-helm@v1
-        with:
-          version: "v3.6.0" # default is latest stable
-
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Deploying Namespace
-        run: |
-          echo $NAMESPACE
-          echo $VALUES
-
-      - name: Deploy
-        run: |
-          aws eks update-kubeconfig --name fsf-prod
-          if [[ $USE_SSM == true ]]; then
-            helm plugin remove ssm || true
-            helm plugin add https://github.com/seripap/helm-ssm || true
-            helm ssm -f $VALUES
-          fi
-
-          sed -i "s/^appVersion:.*$/appVersion: \"$(git describe)\"/" _k/$APP_NAME/Chart.yaml
-
-          if [[ $SIMPLE_DEPLOY == true ]]; then
-            helm upgrade $HELM_NAME _k/$APP_NAME --install --namespace $NAMESPACE --set app.image.tag=sha-$GITHUB_SHA -f $VALUES --wait --timeout $HELM_TIMEOUT
-          else
-            helm upgrade $HELM_NAME _k/$APP_NAME --install --namespace $NAMESPACE --set app.config=$CONF_ENV,volume.path=$CONF_ENV.conf,app.image.tag=sha-$GITHUB_SHA -f $VALUES --wait --timeout $HELM_TIMEOUT --debug
-          fi
+  

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -1,0 +1,87 @@
+name: Build Branch
+on:
+  workflow_call:
+    inputs:
+      dockerfile:
+        default: "Dockerfile"
+        required: false
+        type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  DOCKERFILE: ${{ inputs.dockerfile }}
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    # outputs:
+    #   appenv: ${{ steps.setappenv.outputs.env }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}-v2
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ github.sha }}-v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          file: ${{ env.DOCKERFILE }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      # This only works for pub repos
+      # - id: setappenv
+      #   run: |
+      #     if [[ "$GITHUB_REF_NAME" == *"develop"* ]]; then
+      #       echo "::set-output name=DEPLOY_ENV::development"
+      #     elif [[ "$GITHUB_REF_NAME" == *"master"* ]]; then
+      #       echo "::set-output name=DEPLOY_ENV::production"
+      #     fi

--- a/.github/workflows/build_targeted.yaml
+++ b/.github/workflows/build_targeted.yaml
@@ -1,0 +1,91 @@
+name: Build Targeted
+on:
+  workflow_call:
+    inputs:
+      namespace:
+        required: true
+        type: string
+      dockerfile:
+        default: "Dockerfile"
+        required: false
+        type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  NAMESPACE: ${{ inputs.namespace }}
+  DOCKERFILE: ${{ inputs.dockerfile }}
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    # outputs:
+    #   appenv: ${{ steps.setappenv.outputs.env }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ env.NAMESPACE }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ github.sha }}-${{ env.NAMESPACE }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long,suffix=-${{ env.NAMESPACE }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          file: ${{ env.DOCKERFILE }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      # This only works for pub repos
+      # - id: setappenv
+      #   run: |
+      #     if [[ "$GITHUB_REF_NAME" == *"develop"* ]]; then
+      #       echo "::set-output name=DEPLOY_ENV::development"
+      #     elif [[ "$GITHUB_REF_NAME" == *"master"* ]]; then
+      #       echo "::set-output name=DEPLOY_ENV::production"
+      #     fi

--- a/.github/workflows/deploy_branch.yaml
+++ b/.github/workflows/deploy_branch.yaml
@@ -1,0 +1,123 @@
+name: Deploy Branch
+on:
+  workflow_call:
+    inputs:
+      appname:
+        required: true
+        type: string
+      helm_name:
+        required: true
+        type: string
+      helm_timeout:
+        default: "120s"
+        required: false
+        type: string
+      dev_ns:
+        required: true
+        type: string
+      stg_ns:
+        required: true
+        type: string
+      prod_ns:
+        required: true
+        type: string
+      use_ssm:
+        default: true
+        required: false
+        type: boolean
+      simple_deploy:
+        default: false
+        required: false
+        type: boolean
+      release:
+        default: false
+        required: false
+        type: boolean
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  APP_NAME: ${{ inputs.appname }}
+  HELM_NAME: ${{ inputs.helm_name }}
+  HELM_TIMEOUT: ${{ inputs.helm_timeout }}
+  DEV_NS: ${{ inputs.dev_ns }}
+  STG_NS: ${{ inputs.stg_ns }}
+  PROD_NS: ${{ inputs.prod_ns }}
+  SIMPLE_DEPLOY: ${{ inputs.simple_deploy }}
+  USE_SSM: ${{ inputs.use_ssm }}
+  SHOULD_RELEASE: ${{ inputs.release }}
+
+jobs:
+  Deploy:
+    runs-on: ubuntu-latest
+    # environment: ${{needs.Build.outputs.appenv}}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prepare deployment
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+        run: |
+          if [[ "$SHOULD_RELEASE" == true ]] || [[ "$GITHUB_REF_NAME"  == *"master"* ]] || [[ "$GITHUB_REF_NAME" == *"main"* ]] || [[ "$GITHUB_REF_NAME" == *"nextprod"* ]]; then
+            echo "VALUES=_k/${APP_NAME}/values-prod.yaml" >> $GITHUB_ENV
+            echo "CONF_ENV=prod" >> $GITHUB_ENV
+            echo "NAMESPACE=${PROD_NS}" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          if [[ "$GITHUB_REF_NAME" == *"develop"* ]]; then
+            echo "VALUES=_k/${APP_NAME}/values-dev.yaml" >> $GITHUB_ENV
+            echo "CONF_ENV=dev" >> $GITHUB_ENV
+            echo "NAMESPACE=${DEV_NS}" >> $GITHUB_ENV
+          elif [[ "$GITHUB_REF_NAME"  == *"staging"* ]] || [[ "$GITHUB_REF_NAME"  == *"nextstaging"* ]]; then
+            echo "VALUES=_k/${APP_NAME}/values-stage.yaml" >> $GITHUB_ENV
+            echo "CONF_ENV=stage" >> $GITHUB_ENV
+            echo "NAMESPACE=${STG_NS}" >> $GITHUB_ENV
+          elif [[ "$GITHUB_REF_NAME"  == *"next"* ]]; then
+            echo "VALUES=_k/${APP_NAME}/values-next.yaml" >> $GITHUB_ENV
+            echo "CONF_ENV=next" >> $GITHUB_ENV
+            echo "NAMESPACE=${PROD_NS}" >> $GITHUB_ENV
+          fi
+
+      - uses: azure/setup-kubectl@v1
+        with:
+          version: "v1.22.4"
+
+      - uses: actions/setup-node@v2
+      - uses: azure/setup-helm@v1
+        with:
+          version: "v3.6.0" # default is latest stable
+
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Deploying Namespace
+        run: |
+          echo $NAMESPACE
+          echo $VALUES
+
+      - name: Deploy
+        run: |
+          aws eks update-kubeconfig --name fsf-prod
+          if [[ $USE_SSM == true ]]; then
+            helm plugin remove ssm || true
+            helm plugin add https://github.com/seripap/helm-ssm || true
+            helm ssm -f $VALUES
+          fi
+
+          sed -i "s/^appVersion:.*$/appVersion: \"$(git describe)\"/" _k/$APP_NAME/Chart.yaml
+
+          if [[ $SIMPLE_DEPLOY == true ]]; then
+            helm upgrade $HELM_NAME _k/$APP_NAME --install --namespace $NAMESPACE --set app.image.tag=sha-$GITHUB_SHA -f $VALUES --wait --timeout $HELM_TIMEOUT
+          else
+            helm upgrade $HELM_NAME _k/$APP_NAME --install --namespace $NAMESPACE --set app.config=$CONF_ENV,volume.path=$CONF_ENV.conf,app.image.tag=sha-$GITHUB_SHA -f $VALUES --wait --timeout $HELM_TIMEOUT --debug
+          fi

--- a/.github/workflows/deploy_targeted.yaml
+++ b/.github/workflows/deploy_targeted.yaml
@@ -1,0 +1,91 @@
+name: Deploy Targeted
+on:
+  workflow_call:
+    inputs:
+      appname:
+        required: true
+        type: string
+      helm_name:
+        required: true
+        type: string
+      namespace:
+        required: true
+        type: string
+      helm_config:
+        required: true
+        type: string
+      use_ssm:
+        default: true
+        required: false
+        type: boolean
+      simple_deploy:
+        default: false
+        required: false
+        type: boolean
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+
+env:
+  APP_NAME: ${{ inputs.appname }}
+  HELM_NAME: ${{ inputs.helm_name }}
+  NAMESPACE: ${{ inputs.namespace }}
+  HELM_CONFIG: ${{ inputs.helm_config }}
+  SIMPLE_DEPLOY: ${{ inputs.simple_deploy }}
+  USE_SSM: ${{ inputs.use_ssm }}
+
+jobs:
+  Deploy:
+    runs-on: ubuntu-latest
+    # environment: ${{needs.Build.outputs.appenv}}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prepare deployment
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+        run: |
+          echo "VALUES=_k/${APP_NAME}/values-${HELM_CONFIG}.yaml" >> $GITHUB_ENV
+          echo "CONF_ENV=${HELM_CONFIG}" >> $GITHUB_ENV
+          echo "NAMESPACE=${NAMESPACE}" >> $GITHUB_ENV
+
+      - uses: azure/setup-kubectl@v1
+        with:
+          version: "v1.22.4"
+
+      - uses: actions/setup-node@v2
+      - uses: azure/setup-helm@v1
+        with:
+          version: "v3.6.0" # default is latest stable
+
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Deploying Namespace
+        run: |
+          echo $NAMESPACE
+          echo $VALUES
+
+      - name: Deploy
+        run: |
+          aws eks update-kubeconfig --name fsf-prod
+          if [[ $USE_SSM == true ]]; then
+            helm plugin remove ssm || true
+            helm plugin add https://github.com/seripap/helm-ssm || true
+            helm ssm -f $VALUES
+          fi
+
+          sed -i "s/^appVersion:.*$/appVersion: \"$(git describe)\"/" _k/$APP_NAME/Chart.yaml
+
+          if [[ $SIMPLE_DEPLOY == true ]]; then
+            helm upgrade $HELM_NAME _k/$APP_NAME --install --namespace $NAMESPACE --set app.image.tag=sha-$GITHUB_SHA-$NAMESPACE -f $VALUES --wait --timeout 300s --debug
+          else
+            helm upgrade $HELM_NAME _k/$APP_NAME --install --namespace $NAMESPACE --set app.config=$CONF_ENV,volume.path=$CONF_ENV.conf,app.image.tag=sha-$GITHUB_SHA-$NAMESPACE -f $VALUES --wait --timeout 300s --debug
+          fi

--- a/.github/workflows/targeted.yml
+++ b/.github/workflows/targeted.yml
@@ -45,123 +45,26 @@ env:
 
 jobs:
   Build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    # outputs:
-    #   appenv: ${{ steps.setappenv.outputs.env }}
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-
-      - name: Setup buildx
-        uses: docker/setup-buildx-action@v1
-        id: buildx
-        with:
-          install: true
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ env.NAMESPACE }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.sha }}-${{ env.NAMESPACE }}
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,format=long,suffix=-${{ env.NAMESPACE }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          file: ${{ env.DOCKERFILE }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      # This only works for pub repos
-      # - id: setappenv
-      #   run: |
-      #     if [[ "$GITHUB_REF_NAME" == *"develop"* ]]; then
-      #       echo "::set-output name=DEPLOY_ENV::development"
-      #     elif [[ "$GITHUB_REF_NAME" == *"master"* ]]; then
-      #       echo "::set-output name=DEPLOY_ENV::production"
-      #     fi
-
+    uses: ./build_targeted.yaml
+    with: 
+      namespace: ${{ inputs.namespace }}
+      dockerfile: ${{ inputs.dockerfile }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  
   Deploy:
     needs: [Build]
-    runs-on: ubuntu-latest
-    # environment: ${{needs.Build.outputs.appenv}}
-    steps:
-      - uses: actions/checkout@v2
+    uses: ./deploy_targeted.yaml
+    with:
+      appname: ${{ inputs.appname }}
+      helm_name: ${{ inputs.helm_name }}
+      namespace: ${{ inputs.namespace }}
+      helm_config: ${{ inputs.helm_config }}
+      use_ssm: ${{ inputs.use_ssm }}
+      simple_deploy: ${{ inputs.simple_deploy }}
 
-      - name: Prepare deployment
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-        run: |
-          echo "VALUES=_k/${APP_NAME}/values-${HELM_CONFIG}.yaml" >> $GITHUB_ENV
-          echo "CONF_ENV=${HELM_CONFIG}" >> $GITHUB_ENV
-          echo "NAMESPACE=${NAMESPACE}" >> $GITHUB_ENV
-
-      - uses: azure/setup-kubectl@v1
-        with:
-          version: "v1.22.4"
-
-      - uses: actions/setup-node@v2
-      - uses: azure/setup-helm@v1
-        with:
-          version: "v3.6.0" # default is latest stable
-
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Deploying Namespace
-        run: |
-          echo $NAMESPACE
-          echo $VALUES
-
-      - name: Deploy
-        run: |
-          aws eks update-kubeconfig --name fsf-prod
-          if [[ $USE_SSM == true ]]; then
-            helm plugin remove ssm || true
-            helm plugin add https://github.com/seripap/helm-ssm || true
-            helm ssm -f $VALUES
-          fi
-
-          sed -i "s/^appVersion:.*$/appVersion: \"$(git describe)\"/" _k/$APP_NAME/Chart.yaml
-
-          if [[ $SIMPLE_DEPLOY == true ]]; then
-            helm upgrade $HELM_NAME _k/$APP_NAME --install --namespace $NAMESPACE --set app.image.tag=sha-$GITHUB_SHA-$NAMESPACE -f $VALUES --wait --timeout 300s --debug
-          else
-            helm upgrade $HELM_NAME _k/$APP_NAME --install --namespace $NAMESPACE --set app.config=$CONF_ENV,volume.path=$CONF_ENV.conf,app.image.tag=sha-$GITHUB_SHA-$NAMESPACE -f $VALUES --wait --timeout 300s --debug
-          fi
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    


### PR DESCRIPTION
Splitting build and deploy flows into separate files so that they can be used independently as needed. Example: fsf-scheduled-jobs needs to build and publish image once, and then deploy four times, once for each scheduled job.