### PR TITLE
Update docker/setup-buildx-action to ver2

### DIFF
--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -59,7 +59,7 @@ jobs:
           ref: ${{ inputs.subtree_ref }}
 
       - name: Setup buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         id: buildx
         with:
           install: true

--- a/.github/workflows/build_targeted.yaml
+++ b/.github/workflows/build_targeted.yaml
@@ -67,7 +67,7 @@ jobs:
           ref: ${{ inputs.subtree_ref }}
 
       - name: Setup buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         id: buildx
         with:
           install: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Small fix to update `docker/setup-buildx-action` to ver2.
Ver1 gives a warning:
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

```