### PR TITLE
fix warning `set-output` command is deprecated

### DIFF
--- a/.github/workflows/deploy_branch.yaml
+++ b/.github/workflows/deploy_branch.yaml
@@ -102,7 +102,7 @@ jobs:
           version: "v3.6.0" # default is latest stable
 
       - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy_targeted.yaml
+++ b/.github/workflows/deploy_targeted.yaml
@@ -66,7 +66,7 @@ jobs:
           version: "v3.6.0" # default is latest stable
 
       - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Deploy has a few warnings:
https://github.com/FirstStreet/mothership/actions/runs/5650163308
```
Warning: The `set-output` command is deprecated and will be disabled soon. 
Please upgrade to using Environment Files. 
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```