### PR TITLE
Upgrade aws-actions to v4

### DIFF
--- a/.github/workflows/deploy_branch.yaml
+++ b/.github/workflows/deploy_branch.yaml
@@ -102,7 +102,7 @@ jobs:
           version: "v3.6.0" # default is latest stable
 
       - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy_targeted.yaml
+++ b/.github/workflows/deploy_targeted.yaml
@@ -66,7 +66,7 @@ jobs:
           version: "v3.6.0" # default is latest stable
 
       - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
v2 gives this warning ([link](https://github.com/FirstStreet/mothership/actions/runs/6948593748)):
```
WebhookRelease / Deploy
The following actions uses node12 which is deprecated and will be forced to run on node16: aws-actions/configure-aws-credentials@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

```
