### PR TITLE
Update GitHub actions node-16 to node-20

### DIFF
--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: checkout subtree
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ inputs.needs_subtree }}
         with:
           repository: ${{ inputs.subtree_repo }}
@@ -59,13 +59,13 @@ jobs:
           ref: ${{ inputs.subtree_ref }}
 
       - name: Setup buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         id: buildx
         with:
           install: true
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}-v2
@@ -73,7 +73,7 @@ jobs:
             ${{ runner.os }}-buildx-${{ github.sha }}-v2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -90,7 +90,7 @@ jobs:
             type=sha,format=long
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build_targeted.yaml
+++ b/.github/workflows/build_targeted.yaml
@@ -83,10 +83,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: checkout subtree
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ inputs.needs_subtree }}
         with:
           repository: ${{ inputs.subtree_repo }}
@@ -104,13 +104,13 @@ jobs:
           regex: false
 
       - name: Setup buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         id: buildx
         with:
           install: true
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ env.NAMESPACE }}
@@ -118,7 +118,7 @@ jobs:
             ${{ runner.os }}-buildx-${{ github.sha }}-${{ env.NAMESPACE }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -126,7 +126,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -149,7 +149,7 @@ jobs:
           op document get $file --out-file=$outputf
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: ${{ (github.event_name != 'pull_request') || (inputs.force_docker_push == true) }}

--- a/.github/workflows/deploy_branch.yaml
+++ b/.github/workflows/deploy_branch.yaml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     # environment: ${{needs.Build.outputs.appenv}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare deployment
         env:

--- a/.github/workflows/deploy_branch.yaml
+++ b/.github/workflows/deploy_branch.yaml
@@ -92,9 +92,14 @@ jobs:
             echo "NAMESPACE=${PROD_NS}" >> $GITHUB_ENV
           fi
 
-      - uses: azure/setup-kubectl@v4
-      - uses: actions/setup-node@v4
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-kubectl@v3
+        with:
+          version: "v1.25.2"
+
+      - uses: actions/setup-node@v3
+      - uses: azure/setup-helm@v3
+        with:
+          version: "v3.6.0" # default is latest stable
 
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy_branch.yaml
+++ b/.github/workflows/deploy_branch.yaml
@@ -92,14 +92,9 @@ jobs:
             echo "NAMESPACE=${PROD_NS}" >> $GITHUB_ENV
           fi
 
-      - uses: azure/setup-kubectl@v3
-        with:
-          version: "v1.25.2"
-
-      - uses: actions/setup-node@v3
-      - uses: azure/setup-helm@v3
-        with:
-          version: "v3.6.0" # default is latest stable
+      - uses: azure/setup-kubectl@v4
+      - uses: actions/setup-node@v4
+      - uses: azure/setup-helm@v4
 
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy_targeted.yaml
+++ b/.github/workflows/deploy_targeted.yaml
@@ -56,9 +56,14 @@ jobs:
           echo "CONF_ENV=${HELM_CONFIG}" >> $GITHUB_ENV
           echo "NAMESPACE=${NAMESPACE}" >> $GITHUB_ENV
 
-      - uses: azure/setup-kubectl@v4
-      - uses: actions/setup-node@v4
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-kubectl@v3
+        with:
+          version: "v1.25.2"
+
+      - uses: actions/setup-node@v3
+      - uses: azure/setup-helm@v3
+        with:
+          version: "v3.6.0" # default is latest stable
 
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy_targeted.yaml
+++ b/.github/workflows/deploy_targeted.yaml
@@ -56,14 +56,9 @@ jobs:
           echo "CONF_ENV=${HELM_CONFIG}" >> $GITHUB_ENV
           echo "NAMESPACE=${NAMESPACE}" >> $GITHUB_ENV
 
-      - uses: azure/setup-kubectl@v3
-        with:
-          version: "v1.25.2"
-
-      - uses: actions/setup-node@v3
-      - uses: azure/setup-helm@v3
-        with:
-          version: "v3.6.0" # default is latest stable
+      - uses: azure/setup-kubectl@v4
+      - uses: actions/setup-node@v4
+      - uses: azure/setup-helm@v4
 
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy_targeted.yaml
+++ b/.github/workflows/deploy_targeted.yaml
@@ -45,7 +45,7 @@ jobs:
     runs-on: aws
     # environment: ${{needs.Build.outputs.appenv}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare deployment
         env:


### PR DESCRIPTION
Fixing GitHub warning:
```
 Devrelease / Build / Build
Node.js 16 actions are deprecated.
 Please update the following actions to use Node.js 20: 
actions/checkout@v3, 
docker/setup-buildx-action@v2, 
actions/cache@v3, 
docker/login-action@v2, 
docker/metadata-action@v4, 
docker/build-push-action@v3. 
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
https://github.com/FirstStreet/mothership/actions/runs/8649040530
