### PR TITLE
Explicitly set version

### DIFF
--- a/.github/workflows/build_targeted.yaml
+++ b/.github/workflows/build_targeted.yaml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Find and Replace
         if: ${{ inputs.var_replace_find }}
-        uses: firststreet/gha-find-replace@latest
+        uses: firststreet/gha-find-replace@v1.1.1
         with:
           find: ${{ inputs.var_replace_find }}
           include: ${{ inputs.var_replace_include }}


### PR DESCRIPTION
Uses `v1.1.1` versus `latest`