### PR TITLE
[SE-10363] - Helper Function Deploying Batch with Event Bridge Rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @raymondyong @litvi-l @luzou0526 @leochan-fsf

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @raymondyong @litvi-l @luzou0526 @leochan-fsf
+* @raymondyong @litvi-l @luzou0526 @leochan-fsf @seripap 

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -205,7 +205,7 @@ jobs:
           cdk deploy --require-approval never --app "go mod download && go run ./deployments/deployModels.go ./deployments/helpers.go ./deployments/deploy.go"
           cd ..
 
-      - name: Deploy Event Batch Rule
+      - name: Deploy Batch with Event Bridge Rule
         if: ${{ inputs.deploy_event_bridge_batch }}
         run: |
           export COMPONENT=eventbridgebatch

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -35,6 +35,10 @@ on:
         required: false
         default: false
         type: boolean
+      deploy_event_bridge_batch:
+        required: false
+        default: false
+        type: boolean
       deploy_lambda_event_rule:
         required: false
         default: false
@@ -93,6 +97,9 @@ on:
       BATCH_SECURITY_GROUP_IDS:
         required: false
         type: string
+      BATCH_JOB_COMMAND:
+        required: false
+        type: string
       BATCH_DISK_STORAGE:
         required: false
         type: string
@@ -126,6 +133,7 @@ jobs:
       BATCH_MAX_VCPUS: ${{ inputs.BATCH_MAX_VCPUS }}
       BATCH_SUBNET_IDS: ${{ inputs.BATCH_SUBNET_IDS }}
       BATCH_SECURITY_GROUP_IDS: ${{ inputs.BATCH_SECURITY_GROUP_IDS }}
+      BATCH_JOB_COMMAND: ${{ inputs.BATCH_JOB_COMMAND }}
       BATCH_DISK_STORAGE: ${{ inputs.BATCH_DISK_STORAGE }}
       BATCH_RUNTIME_CPU: ${{ inputs.BATCH_RUNTIME_CPU }}
       
@@ -194,6 +202,14 @@ jobs:
         run: |
           export COMPONENT=batch
           cd ${{ inputs.subtree_path }} 
+          cdk deploy --require-approval never --app "go mod download && go run ./deployments/deployModels.go ./deployments/helpers.go ./deployments/deploy.go"
+          cd ..
+
+      - name: Deploy Event Batch Rule
+        if: ${{ inputs.deploy_event_bridge_batch }}
+        run: |
+          export COMPONENT=eventbridgebatch
+          cd ${{ inputs.subtree_path }}
           cdk deploy --require-approval never --app "go mod download && go run ./deployments/deployModels.go ./deployments/helpers.go ./deployments/deploy.go"
           cd ..
 

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -85,6 +85,9 @@ on:
       SOURCE_EVENT_DETAIL_TYPES:
         required: false
         type: string
+      SOURCE_EVENT_BUCKET_NAME:
+        required: false
+        type: string
       BATCH_CLUSTER_TYPE:
         required: false
         type: string
@@ -121,6 +124,7 @@ jobs:
       ECR_REPO_NAME: ${{ inputs.ECR_REPO_NAME }}
       SOURCE_EVENT_BUS_NAME: ${{ inputs.SOURCE_EVENT_BUS_NAME }}
       SOURCE_EVENT_SOURCES: ${{ inputs.SOURCE_EVENT_SOURCES }}
+      SOURCE_EVENT_BUCKET_NAME: ${{ inputs.SOURCE_EVENT_BUCKET_NAME }}
       SOURCE_EVENT_DETAIL_TYPES: ${{ inputs.SOURCE_EVENT_DETAIL_TYPES }}
       EVENT_RULE_NAME: ${{ inputs.EVENT_RULE_NAME }}
       LAMBDA_FUNC_NAME: ${{ inputs.LAMBDA_FUNC_NAME }}


### PR DESCRIPTION
Adding `inputs. deploy_event_bridge_batch` and a parameterizing the command fed to batch jobs with `BATCH_JOB_COMMAND`.

Also added `CODEOWNERS`.

Related PR: https://github.com/FirstStreet/fs-deployment-pipeline/pull/7