### PR TITLE
[SE-10615] Add EventBridge Parameter to S3 Bucket

### DIFF
--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -132,6 +132,10 @@ on:
         description: "Lifecycle for objects in the format of prefix:ttl_days, separated by spaces. ex: 'upload:7 result:30' means files under upload/ will expire in 7 days and files under result/ will expire in 30 days"
         required: false
         type: string
+      S3_EVENTBRIDGE_ENABLED:
+        description: "Set to true to send notifications to Amazon EventBridge. Default: false"
+        required: false
+        type: boolean
     secrets:
       SUBTREE_TOKEN:
         required: true

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -172,6 +172,7 @@ jobs:
       BATCH_DOCKERFILE_PATH: ${{ inputs.BATCH_DOCKERFILE_PATH }}
       S3_BUCKET_NAME_PREFIX: ${{ inputs.S3_BUCKET_NAME_PREFIX }}
       S3_TTL_SPEC: ${{ inputs.S3_TTL_SPEC }}
+      S3_EVENTBRIDGE_ENABLED: ${{ inputs.S3_EVENTBRIDGE_ENABLED }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Adding `S3_EVENTBRIDGE_ENABLED` to the CDK deploy to enable enabling EventBridge on S3 Buckets.

Related PR: https://github.com/FirstStreet/fs-deployment-pipeline/pull/16