### PR TITLE
[SE-11071] - Update buildx version

### DIFF
--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -69,6 +69,7 @@ jobs:
         id: buildx
         with:
           install: true
+          version: v0.22.0
 
       - name: Cache Docker layers
         uses: actions/cache@v4

--- a/.github/workflows/build_targeted.yaml
+++ b/.github/workflows/build_targeted.yaml
@@ -115,6 +115,7 @@ jobs:
         id: buildx
         with:
           install: true
+          version: v0.22.0
 
       - name: Cache Docker layers
         uses: actions/cache@v4

--- a/.github/workflows/build_with_role.yaml
+++ b/.github/workflows/build_with_role.yaml
@@ -111,6 +111,7 @@ jobs:
         id: buildx
         with:
           install: true
+          version: v0.22.0
 
       - name: Cache Docker layers
         uses: actions/cache@v4

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -203,7 +203,7 @@ jobs:
           cd ${{ inputs.subtree_path }} 
           go mod tidy      
           go mod vendor
-          cd ..  
+          cd ..
 
       - name: Setup node
         if: ${{ inputs.runs_on == 'aws' }}
@@ -212,10 +212,12 @@ jobs:
           node-version: lts/*
 
       - name: Install deployment dependencies
-        run: npm install -g aws-cdk 
+        run: npm install -g aws-cdk
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.8.0
+        with:
+          version: v0.22.0
 
       - name: Log into ghrc registry
         uses: docker/login-action@v3.3.0
@@ -231,7 +233,7 @@ jobs:
           cd ${{ inputs.subtree_path }} 
           cdk deploy --require-approval never --app "go mod download && go run ./deployments/deployModels.go ./deployments/helpers.go ./deployments/deploy.go"
           cd ..
-      
+
       - name: Deploy Docker
         if: ${{ inputs.deploy_docker_image }}
         run: |
@@ -239,7 +241,7 @@ jobs:
           cd ${{ inputs.subtree_path }} 
           cdk deploy --require-approval never --app "go mod download && go run ./deployments/deployModels.go ./deployments/helpers.go ./deployments/deploy.go"
           cd ..
-      
+
       - name: Deploy Batch
         if: ${{ inputs.deploy_batch }}
         run: |


### PR DESCRIPTION
Github builds are failing due Github migrating to a new cache service. This PR updated `buildx` version
See links below:

https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

https://github.com/docker/build-push-action/issues/1345

![image](https://github.com/user-attachments/assets/dd1d51b0-6cfb-4a43-a65a-f92ab6c95bdb)
