### PR TITLE
Update build_targeted workflow

### DIFF
--- a/.github/workflows/build_targeted.yaml
+++ b/.github/workflows/build_targeted.yaml
@@ -114,15 +114,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         id: buildx
         with:
+          version: latest
           install: true
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.ref_name }}-${{ env.NAMESPACE }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.ref_name }}-${{ env.NAMESPACE }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
update targeted workflow due to gh cacheing update, cache step not needed with `type=gha` and latest versions of buildx