### PR TITLE
[SE-11491] Add minimum configuration for docker lambda deployments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @raymondyong @litvi-l @luzou0526 @leochan-fsf @seripap 
+* @raymondyong @litvi-l @luzou0526 @leochan-fsf @seripap @pymaxion

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -79,7 +79,6 @@ on:
         description: "Relative path to Dockerfile against root, default is the Dockerfile under root, other ex: jobs/stats_refresh/Dockerfile"
         required: false
         type: string
-        default: Dockerfile
       LAMBDA_HANDLER_NAME:
         required: false
         type: string
@@ -135,7 +134,6 @@ on:
         description: "Relative path to Dockerfile against root, default is the Dockerfile under root, other ex: jobs/stats_refresh/Dockerfile"
         required: false
         type: string
-        default: Dockerfile
       S3_BUCKET_NAME_PREFIX:
         description: "Prefix of the S3 bucket, env or additional static values will be appended to this prefix"
         required: false

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -255,7 +255,7 @@ jobs:
           cd ..
 
       - name: Deploy Docker Lambda
-        if: ${{ input.deploy_docker_lambda }}
+        if: ${{ inputs.deploy_docker_lambda }}
         run: |
           export COMPONENT=dockerlambda
           cd ${{ inputs.subtree_path }}

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -31,6 +31,10 @@ on:
         required: false
         default: false
         type: boolean
+      deploy_docker_lambda:
+        required: false
+        default: false
+        type: boolean
       deploy_batch:
         required: false
         default: false
@@ -71,6 +75,11 @@ on:
       LAMBDA_ASSET_PATH:
         required: false
         type: string
+      LAMBDA_DOCKERFILE_PATH:
+        description: "Relative path to Dockerfile against root, default is the Dockerfile under root, other ex: jobs/stats_refresh/Dockerfile"
+        required: false
+        type: string
+        default: Dockerfile
       LAMBDA_HANDLER_NAME:
         required: false
         type: string
@@ -80,10 +89,13 @@ on:
       LAMBDA_ENV_VARS:
         required: false
         type: string
-      EVENT_RULE_NAME:
+      LAMBDA_RUNTIME_ARCH:
         required: false
         type: string
-      LAMBDA_RUNTIME_ARCH:
+      LAMBDA_VPC_NAME:
+        required: false
+        type: string
+      EVENT_RULE_NAME:
         required: false
         type: string
       SOURCE_EVENT_BUS_NAME:
@@ -156,8 +168,10 @@ jobs:
       EVENT_RULE_NAME: ${{ inputs.EVENT_RULE_NAME }}
       LAMBDA_FUNC_NAME: ${{ inputs.LAMBDA_FUNC_NAME }}
       LAMBDA_ASSET_PATH: ${{ inputs.LAMBDA_ASSET_PATH }}
+      LAMBDA_DOCKERFILE_PATH: ${{ inputs.LAMBDA_DOCKERFILE_PATH }}
       LAMBDA_HANDLER_NAME: ${{ inputs.LAMBDA_HANDLER_NAME }}
       LAMBDA_RUNTIME_ARCH: ${{ inputs.LAMBDA_RUNTIME_ARCH}}
+      LAMBDA_VPC_NAME: ${{ inputs.LAMBDA_VPC_NAME }}
       LAMBDA_TIMEOUT_IN_SECONDS: ${{ inputs.LAMBDA_TIMEOUT_IN_SECONDS }}
       LAMBDA_ENV_VARS: ${{ inputs.LAMBDA_ENV_VARS }}
       ACCOUNT_ID: ${{ inputs.ACCOUNT_ID }}
@@ -239,7 +253,15 @@ jobs:
           cd ${{ inputs.subtree_path }} 
           cdk deploy --require-approval never --app "go mod download && go run ./deployments/deployModels.go ./deployments/helpers.go ./deployments/deploy.go"
           cd ..
-      
+
+      - name: Deploy Docker Lambda
+        if: ${{ input.deploy_docker_lambda }}
+        run: |
+          export COMPONENT=dockerlambda
+          cd ${{ inputs.subtree_path }}
+          cdk deploy --require-approval never --app "go mod download && go run ./deployments/deployModels.go ./deployments/helpers.go ./deployments/deploy.go"
+          cd ..
+
       - name: Deploy Batch
         if: ${{ inputs.deploy_batch }}
         run: |


### PR DESCRIPTION
## Issue Link
https://linear.app/fsf/issue/SE-11491

## Change Summary
This PR adds the bare minimum inputs, environment variables, and Github job steps necessary to deploy a Dockerized Go Lambda to AWS. 

### PLEASE NOTE: We may need to add more configuration as we implement [SE-11491](https://linear.app/fsf/issue/SE-11491), depending on our deployment preferences. I'm waiting to add further configuration until it is obviously needed.

## Related PRs
* [[SE-11491] Add CDK logic to deploy Dockerized lambda code](https://github.com/FirstStreet/fs-deployment-pipeline/pull/22)

## Testing
* Used changes in this PR to deploy a [barebones Dockerized Go lambda](https://github.com/FirstStreet/patrick-code-snippets/tree/57df715584a36f96b1cfd6be1ce466b6dcdabd6f) to AWS. 
* Example successful deployment workflow [here](https://github.com/FirstStreet/patrick-code-snippets/actions/runs/15426486461/job/43414571288)
