### PR TITLE
[SE-11491] add DOCKER_IMAGE_TAG to inputs

### DIFF
--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -69,6 +69,9 @@ on:
       ECR_REPO_NAME:
         required: false
         type: string
+      DOCKER_IMAGE_TAG:
+        required: false
+        type: string
       LAMBDA_FUNC_NAME:
         required: false
         type: string
@@ -159,6 +162,7 @@ jobs:
       ENV: ${{ inputs.ENV }}
       STACK_ID_PREFIX: ${{ inputs.STACK_ID_PREFIX }}
       ECR_REPO_NAME: ${{ inputs.ECR_REPO_NAME }}
+      DOCKER_IMAGE_TAG: ${{ inputs.DOCKER_IMAGE_TAG }}
       SOURCE_EVENT_BUS_NAME: ${{ inputs.SOURCE_EVENT_BUS_NAME }}
       SOURCE_EVENT_SOURCES: ${{ inputs.SOURCE_EVENT_SOURCES }}
       SOURCE_EVENT_BUCKET_NAME: ${{ inputs.SOURCE_EVENT_BUCKET_NAME }}


### PR DESCRIPTION
## Issue Link
https://linear.app/fsf/issue/SE-11491

## Summary of Changes
This PR adds `DOCKER_IMAGE_TAG` to the list of available environment variable inputs for Github action deployments. This is in response to [lu's comment on a prior PR](https://github.com/FirstStreet/fs-deployment-pipeline/pull/22#discussion_r2125146348), which I think is a very good idea.

## Related PRs
* [[SE-11491] implement logic to support git commit hash as image tag](https://github.com/FirstStreet/fs-deployment-pipeline/pull/23)

## Testing
* Example usage [here](https://github.com/FirstStreet/patrick-code-snippets/blob/7a67d7d23dd046589d885c695f07d5680279226b/.github/workflows/manual.yml#L49)
* Used these changes to deploy a [barebones Dockerized Go lambda](https://github.com/FirstStreet/patrick-code-snippets/tree/7a67d7d23dd046589d885c695f07d5680279226b) to AWS. Confirmed that the git commit hash matches the image tag in ECR and Lambda.
* Example successful deployment workflow [here](https://github.com/FirstStreet/patrick-code-snippets/actions/runs/15447749056/job/43481851775)