### PR TITLE
[SE-11491] Add input for lambda custom IAM policy

### DIFF
--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -88,6 +88,9 @@ on:
       LAMBDA_TIMEOUT_IN_SECONDS:
         required: false
         type: string
+      LAMBDA_ENV_VARS:
+        required: false
+        type: string
       LAMBDA_DESCRIPTION:
         required: false
         type: string
@@ -187,8 +190,9 @@ jobs:
       LAMBDA_RUNTIME_ARCH: ${{ inputs.LAMBDA_RUNTIME_ARCH}}
       LAMBDA_MEMORY_SIZE_MB: ${{ inputs.LAMBDA_MEMORY_SIZE_MB }}
       LAMBDA_VPC_NAME: ${{ inputs.LAMBDA_VPC_NAME }}
-      LAMBDA_TIMEOUT_IN_SECONDS: ${{ inputs.LAMBDA_TIMEOUT_IN_SECONDS }}
       LAMBDA_CUSTOM_IAM_POLICY: ${{ inputs.LAMBDA_CUSTOM_IAM_POLICY }}
+      LAMBDA_TIMEOUT_IN_SECONDS: ${{ inputs.LAMBDA_TIMEOUT_IN_SECONDS }}
+      LAMBDA_ENV_VARS: ${{ inputs.LAMBDA_ENV_VARS }}
       ACCOUNT_ID: ${{ inputs.ACCOUNT_ID }}
       REGION: ${{ inputs.aws_region }}
       BATCH_CLUSTER_TYPE: ${{ inputs.BATCH_CLUSTER_TYPE }}

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -103,7 +103,7 @@ on:
       LAMBDA_VPC_NAME:
         required: false
         type: string
-      LAMBDA_CUSTOM_IAM_POLICY:
+      LAMBDA_CUSTOM_IAM_POLICY_FILE:
         required: false
         type: string
       EVENT_RULE_NAME:
@@ -190,7 +190,6 @@ jobs:
       LAMBDA_RUNTIME_ARCH: ${{ inputs.LAMBDA_RUNTIME_ARCH}}
       LAMBDA_MEMORY_SIZE_MB: ${{ inputs.LAMBDA_MEMORY_SIZE_MB }}
       LAMBDA_VPC_NAME: ${{ inputs.LAMBDA_VPC_NAME }}
-      LAMBDA_CUSTOM_IAM_POLICY: ${{ inputs.LAMBDA_CUSTOM_IAM_POLICY }}
       LAMBDA_TIMEOUT_IN_SECONDS: ${{ inputs.LAMBDA_TIMEOUT_IN_SECONDS }}
       LAMBDA_ENV_VARS: ${{ inputs.LAMBDA_ENV_VARS }}
       ACCOUNT_ID: ${{ inputs.ACCOUNT_ID }}
@@ -277,6 +276,10 @@ jobs:
       - name: Deploy Docker Lambda
         if: ${{ inputs.deploy_docker_lambda }}
         run: |
+          if [ -f "${{ inputs.LAMBDA_CUSTOM_IAM_POLICY }}" ]; then
+            echo "Found custom IAM policy file. Contents will be passed into the LAMBDA_CUSTOM_IAM_POLICY env variable"
+            export LAMBDA_CUSTOM_IAM_POLICY=$(cat "${{ inputs.LAMBDA_CUSTOM_IAM_POLICY }}")
+          fi
           export COMPONENT=dockerlambda
           cd ${{ inputs.subtree_path }}
           cdk deploy --require-approval never --app "go mod download && go run ./deployments/deploy_models.go ./deployments/helpers.go ./deployments/deploy.go"

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -276,9 +276,9 @@ jobs:
       - name: Deploy Docker Lambda
         if: ${{ inputs.deploy_docker_lambda }}
         run: |
-          if [ -f "${{ inputs.LAMBDA_CUSTOM_IAM_POLICY }}" ]; then
+          if [ -f "${{ inputs.LAMBDA_CUSTOM_IAM_POLICY_FILE }}" ]; then
             echo "Found custom IAM policy file. Contents will be passed into the LAMBDA_CUSTOM_IAM_POLICY env variable"
-            export LAMBDA_CUSTOM_IAM_POLICY=$(cat "${{ inputs.LAMBDA_CUSTOM_IAM_POLICY }}")
+            export LAMBDA_CUSTOM_IAM_POLICY=$(cat "${{ inputs.LAMBDA_CUSTOM_IAM_POLICY_FILE }}")
           fi
           export COMPONENT=dockerlambda
           cd ${{ inputs.subtree_path }}

--- a/.github/workflows/cdk_deploy.yaml
+++ b/.github/workflows/cdk_deploy.yaml
@@ -88,9 +88,6 @@ on:
       LAMBDA_TIMEOUT_IN_SECONDS:
         required: false
         type: string
-      LAMBDA_ENV_VARS:
-        required: false
-        type: string
       LAMBDA_DESCRIPTION:
         required: false
         type: string
@@ -101,6 +98,9 @@ on:
         required: false
         type: number
       LAMBDA_VPC_NAME:
+        required: false
+        type: string
+      LAMBDA_CUSTOM_IAM_POLICY:
         required: false
         type: string
       EVENT_RULE_NAME:
@@ -188,7 +188,7 @@ jobs:
       LAMBDA_MEMORY_SIZE_MB: ${{ inputs.LAMBDA_MEMORY_SIZE_MB }}
       LAMBDA_VPC_NAME: ${{ inputs.LAMBDA_VPC_NAME }}
       LAMBDA_TIMEOUT_IN_SECONDS: ${{ inputs.LAMBDA_TIMEOUT_IN_SECONDS }}
-      LAMBDA_ENV_VARS: ${{ inputs.LAMBDA_ENV_VARS }}
+      LAMBDA_CUSTOM_IAM_POLICY: ${{ inputs.LAMBDA_CUSTOM_IAM_POLICY }}
       ACCOUNT_ID: ${{ inputs.ACCOUNT_ID }}
       REGION: ${{ inputs.aws_region }}
       BATCH_CLUSTER_TYPE: ${{ inputs.BATCH_CLUSTER_TYPE }}


### PR DESCRIPTION
Related PR: [[SE-11491] Add CDK logic for attaching custom IAM policy to dockerized lambda](https://github.com/FirstStreet/fs-deployment-pipeline/pull/26)

Example use:
```yaml
jobs:
  Build:
    permissions:
      ...
    uses: FirstStreet/ci-workflow/.github/workflows/cdk_deploy.yaml@patrick/custom-iam-policy
    with:
      ...
      LAMBDA_DOCKERFILE_PATH: dockerlambda/Dockerfile
      LAMBDA_VPC_NAME: vpc-eks-global-dev
      LAMBDA_MEMORY_SIZE_MB: 256
      LAMBDA_CUSTOM_IAM_POLICY: |
        {
          "Version": "2012-10-17",
          "Statement": [
            {
              "Effect": "Allow",
              "Action": [
                "cloudformation:DescribeStacks",
                "lambda:InvokeFunction"
              ],
              "Resource": "*"
            }
          ]
        }
    secrets:
      ...
```